### PR TITLE
Add git ref and package setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ You can also chain this job with your unittests to only trigger release if tests
 * `parse-changelog`: If `true`, extract GitHub release notes from the `CHANGELOG.md` (assuming [keep a changelog
 ](https://keepachangelog.com/) format)
 * `pkg-name` (Optional): Package name (auto-detected).
-* `git-ref` (Optional): Git ref (e.g. SHA or tag). If `skip`, the repository is
-  not checked out. 
+* `git-ref` (Optional): Git ref (e.g. SHA or tag). If `git-ref: skip`, the repository is
+  not checked out (this can be used to manually checkout and update the repo before publishing).
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ You can also chain this job with your unittests to only trigger release if tests
 * `parse-changelog`: If `true`, extract GitHub release notes from the `CHANGELOG.md` (assuming [keep a changelog
 ](https://keepachangelog.com/) format)
 * `pkg-name` (Optional): Package name (auto-detected).
+* `git-ref` (Optional): Git ref (e.g. SHA or tag). If `skip`, the repository is
+  not checked out. 
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -21,11 +21,18 @@ inputs:
   pkg-name:
     description: 'Name of the PyPI package (optional).'
     required: false
+  git-ref:
+    description: 'Git ref (e.g. SHA or tag) (optional).'
+    required: false
+    default: ''  # Use 'skip' to skip repository checkout
 
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - if: inputs.git-ref != 'skip'
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.git-ref }}
 
     # Setup Python
     - uses: actions/setup-python@v4


### PR DESCRIPTION
The new option `git-ref` is useful:
- to specify a commit for manual release
- to allow the user to control repository state prior to releasing