### PR TITLE
Revert "add: and extra check for editable files with "import __editable__" in…"

### DIFF
--- a/src/compare_version.py
+++ b/src/compare_version.py
@@ -63,11 +63,10 @@ def _is_editable(dist: importlib.metadata.PathDistribution) -> bool:
         return False
     (pth_file,) = all_pth
     content = pth_file.read_text()
-    # Here, should check with github action path
-    editable = content.startswith("/") or "import __editable__" in content
-    if editable:
+    if content.startswith("/"):  # TODO: To delete
         print(content)
-    return content
+    # Here, should check with github action path
+    return content.startswith("/")
 
 
 def find_pkg_name() -> str:


### PR DESCRIPTION
Reverts etils-actions/pypi-auto-publish#3

This is a tentative revert pr as mentioned in:
https://github.com/etils-actions/pypi-auto-publish/issues/2

I now get:
```
Traceback (most recent call last):
  File "/home/runner/work/_actions/etils-actions/pypi-auto-publish/v1/src/compare_version.py", line 147, in <module>
import __editable___bencher_1_20_0_finder; __editable___bencher_1_20_0_finder.install()
    main()
  File "/home/runner/work/_actions/etils-actions/pypi-auto-publish/v1/src/compare_version.py", line 45, in main
    pkg_name = find_pkg_name()
               ^^^^^^^^^^^^^^^
  File "/home/runner/work/_actions/etils-actions/pypi-auto-publish/v1/src/compare_version.py", line 79, in find_pkg_name
    raise ValueError(
ValueError: Could not auto-infer the package name: ['bencher', 'setuptools']. Please open an issue.
```

I believe this could be due to the change I added.